### PR TITLE
Update computeStateDisplay for HA 0.109

### DIFF
--- a/src/compute-state-display.ts
+++ b/src/compute-state-display.ts
@@ -10,26 +10,17 @@ export function computeStateDisplay(
   stateObj: HassEntity,
   language: string
 ): string {
-  let display: string | undefined;
+  if (stateObj.state === "unknown" || stateObj.state === "unavailable") {
+    return localize(`state.default.${stateObj.state}`);
+  }
+
+  if (stateObj.attributes.unit_of_measurement) {
+    return `${stateObj.state} ${stateObj.attributes.unit_of_measurement}`;
+  }
+
   const domain = computeStateDomain(stateObj);
 
-  if (domain === "binary_sensor") {
-    // Try device class translation, then default binary sensor translation
-    if (stateObj.attributes.device_class) {
-      display = localize(
-        `state.${domain}.${stateObj.attributes.device_class}.${stateObj.state}`
-      );
-    }
-
-    if (!display) {
-      display = localize(`state.${domain}.default.${stateObj.state}`);
-    }
-  } else if (
-    stateObj.attributes.unit_of_measurement &&
-    !["unknown", "unavailable"].includes(stateObj.state)
-  ) {
-    display = stateObj.state + " " + stateObj.attributes.unit_of_measurement;
-  } else if (domain === "input_datetime") {
+  if (domain === "input_datetime") {
     let date: Date;
     if (!stateObj.attributes.has_time) {
       date = new Date(
@@ -37,8 +28,9 @@ export function computeStateDisplay(
         stateObj.attributes.month - 1,
         stateObj.attributes.day
       );
-      display = formatDate(date, language);
-    } else if (!stateObj.attributes.has_date) {
+      return formatDate(date, language);
+    }
+    if (!stateObj.attributes.has_date) {
       const now = new Date();
       date = new Date(
         // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
@@ -49,38 +41,28 @@ export function computeStateDisplay(
         stateObj.attributes.hour,
         stateObj.attributes.minute
       );
-      display = formatTime(date, language);
-    } else {
-      date = new Date(
-        stateObj.attributes.year,
-        stateObj.attributes.month - 1,
-        stateObj.attributes.day,
-        stateObj.attributes.hour,
-        stateObj.attributes.minute
-      );
-      display = formatDateTime(date, language);
+      return formatTime(date, language);
     }
-  } else if (domain === "zwave") {
-    if (["initializing", "dead"].includes(stateObj.state)) {
-      display = localize(
-        `state.zwave.query_stage.${stateObj.state}`,
-        "query_stage",
-        stateObj.attributes.query_stage
-      );
-    } else {
-      display = localize(`state.zwave.default.${stateObj.state}`);
-    }
-  } else {
-    display = localize(`state.${domain}.${stateObj.state}`);
+
+    date = new Date(
+      stateObj.attributes.year,
+      stateObj.attributes.month - 1,
+      stateObj.attributes.day,
+      stateObj.attributes.hour,
+      stateObj.attributes.minute
+    );
+    return formatDateTime(date, language);
   }
 
-  // Fall back to default, component backend translation, or raw state if nothing else matches.
-  if (!display) {
-    display =
-      localize(`state.default.${stateObj.state}`) ||
-      localize(`component.${domain}.state.${stateObj.state}`) ||
-      stateObj.state;
-  }
-
-  return display;
+  return (
+    // Return device class translation
+    (stateObj.attributes.device_class &&
+      localize(
+        `component.${domain}.state.${stateObj.attributes.device_class}.${stateObj.state}`
+      )) ||
+    // Return default translation
+    localize(`component.${domain}.state._.${stateObj.state}`) ||
+    // We don't know! Return the raw state.
+    stateObj.state
+  );
 }


### PR DESCRIPTION
This migrates custom-card-helpers to use the new computeStateDisplay logic that Home Assistant uses too. 

Tested in HA, untested within custom-card-helpers. Note, in HA we have a fallback for when the function is used with a HA version from before 0.109 (for Cast), but that relies on functionality not available in custom-card-helpers.

https://github.com/home-assistant/frontend/blob/dev/src/common/entity/compute_state_display.ts#L90