### PR TITLE
Add support for fire-dom-event

### DIFF
--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -73,6 +73,10 @@ export const handleActionConfig = (
       const [domain, service] = actionConfig.service.split(".", 2);
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("success");
+      break;
+    }
+    case "fire-dom-event": {
+      fireEvent(node, "ll-custom", actionConfig);
     }
   }
 };


### PR DESCRIPTION
Related to https://community.home-assistant.io/t/browser-mod-turn-your-browser-into-a-controllable-device-and-a-media-player/123806/971