### PR TITLE
Add hass.hassUrl function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -237,7 +237,7 @@ export interface HomeAssistant {
   ) => Promise<Response>;
   sendWS: (msg: MessageBase) => Promise<void>;
   callWS: <T>(msg: MessageBase) => Promise<T>;
-  hassUrl: (path?) => string;
+  hassUrl: (path?: string) => string;
 }
 
 export enum NumberFormat {


### PR DESCRIPTION
Adds `hassUrl` method to `HomeAssistant` interface

Source:
https://github.com/home-assistant/frontend/blob/dev/src/types.ts#L225