### PR TITLE
fix: renaming of `app-drawer-layout` -> `ha-drawer` in HA 2023.4

### DIFF
--- a/src/get-lovelace.ts
+++ b/src/get-lovelace.ts
@@ -1,17 +1,23 @@
+import { HuiRootElement } from "./types";
+
 export const getLovelace = () => {
-    let root: any = document.querySelector('home-assistant');
-    root = root && root.shadowRoot;
-    root = root && root.querySelector('home-assistant-main');
-    root = root && root.shadowRoot;
-    root = root && root.querySelector('app-drawer-layout partial-panel-resolver');
-    root = root && root.shadowRoot || root;
-    root = root && root.querySelector('ha-panel-lovelace');
-    root = root && root.shadowRoot;
-    root = root && root.querySelector('hui-root');
-    if (root) {
-        const ll = root.lovelace;
-        ll.current_view = root.___curView;
-        return ll;
-    }
-    return null;
-}
+  const root = document
+    .querySelector("home-assistant")
+    ?.shadowRoot?.querySelector("home-assistant-main")?.shadowRoot;
+
+  const resolver =
+    root?.querySelector("ha-drawer partial-panel-resolver") ||
+    root?.querySelector("app-drawer-layout partial-panel-resolver");
+
+  const huiRoot = (resolver?.shadowRoot || resolver)
+    ?.querySelector<HuiRootElement>("ha-panel-lovelace")
+    ?.shadowRoot?.querySelector<HuiRootElement>("hui-root");
+
+  if (huiRoot) {
+    const ll = huiRoot.lovelace;
+    ll.current_view = huiRoot.___curView;
+    return ll;
+  }
+
+  return null;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,15 @@ export type ActionConfig =
   | CustomActionConfig
   | ToggleMenuActionConfig;
 
+export interface HuiRootElement extends HTMLElement {
+  lovelace: {
+    config: LovelaceConfig;
+    current_view: number;
+    [key: string]: any;
+  };
+  ___curView: number;
+}
+
 export interface Window {
   // Custom panel entry point url
   customPanelJS: string;


### PR DESCRIPTION
Fixes https://github.com/custom-cards/custom-card-helpers/issues/72

Fixes the `getLovelace` function, this is similar to this PR https://github.com/custom-cards/custom-card-helpers/pull/73 but it remains backwards compatible with previous versions of HA